### PR TITLE
Port to hmatrix

### DIFF
--- a/OpticML/OpticML.cabal
+++ b/OpticML/OpticML.cabal
@@ -33,7 +33,7 @@ library
     -- other-extensions:
     build-depends:    
         base ^>=4.16.4.0,
-        matrix,
+        hmatrix >= 0.20.2,
         normaldistribution,
         random
     
@@ -72,7 +72,7 @@ executable OpticML
     -- other-extensions:
     build-depends:
         base ^>=4.16.4.0,
-        matrix,
+        hmatrix >= 0.20.2,
         bytestring >= 0.11.3.1,
         cassava >= 0.5.3.0,
         vector >= 0.13.0.0,

--- a/OpticML/OpticML.cabal
+++ b/OpticML/OpticML.cabal
@@ -110,6 +110,6 @@ test-suite OpticML-test
         base ^>=4.16.4.0,
         tasty,
         tasty-hunit,
-        matrix,
+        hmatrix >= 0.20.2,
         OpticML
 

--- a/OpticML/OpticML.cabal
+++ b/OpticML/OpticML.cabal
@@ -110,5 +110,6 @@ test-suite OpticML-test
         base ^>=4.16.4.0,
         tasty,
         tasty-hunit,
+        matrix,
         OpticML
 

--- a/OpticML/examples/Playground/ComponentTests.hs
+++ b/OpticML/examples/Playground/ComponentTests.hs
@@ -3,17 +3,17 @@
 
 module Playground.ComponentTests where
 
-import Data.Matrix (Matrix, fromLists, fromList)
-import OpticML (Para', Lens, Lens', Para(..), dense, identityL, rev, lr, liftPara, mse, sigmoid, update, alongside, (|.|), EmptyParam(..))
+import Numeric.LinearAlgebra (Matrix, fromLists, Vector, fromList)
+import OpticML (Para', Lens, Lens', Para(..), dense, identityL, rev, lr, liftPara, mse, sigmoid, update, alongside, (|.|), EmptyParam(..), fwd, linearP)
 
-type ModelParam = (EmptyParam, (Matrix Double, Matrix Double))
-type Result = Matrix Double
-type Input = Matrix Double
-type Expected = Matrix Double
+type ModelParam = (EmptyParam, (Vector Double, Matrix Double))
+type Result = Vector Double
+type Input = Vector Double
+type Expected = Vector Double
 type Loss = Double
 
 type LRParam = EmptyParam
-type LossParam = Matrix Double
+type LossParam = Vector Double
 type LearnerParam = ((LRParam, LossParam), ModelParam)
 
 testModel :: IO ()
@@ -25,17 +25,17 @@ testModel = do
             [4, 5, 6]
           ]
 
-  let x :: Matrix Double
-      x = fromList 3 1 [7, 8, 9]
+  let x :: Vector Double
+      x = fromList [7, 8, 9]
 
-  let y :: Matrix Double
-      y = fromList 2 1 [150, 222]
+  let y :: Vector Double
+      y = fromList [150, 222]
 
-  let b :: Matrix Double
-      b = fromList 2 1 [100, 100]
+  let b :: Vector Double
+      b = fromList [100, 100]
 
-  let loss :: Matrix Double
-      loss = fromList 2 1 [10, 20]
+  let loss :: Vector Double
+      loss = fromList [10, 20]
 
   let m' :: Matrix Double
       m' =
@@ -44,83 +44,88 @@ testModel = do
             [140, 160, 180]
           ]
 
-  let x' :: Matrix Double
-      x' = fromList 3 1 [90, 120, 150]
+  let x' :: Vector Double
+      x' = fromList [90, 120, 150]
 
-  -- let pl :: Para' (Matrix Double) (Matrix Double, Matrix Double) (Matrix Double)
-  --     pl = linearP (3, 2)
-  -- let res = fwd (plens pl) (m, x) -- [50 122]
-  -- let res = rev (plens pl) (loss, (m, x)) -- ([[70, 80, 90], [140, 160, 180]], [90, 120, 150])
+  let pl1 :: Para' (Matrix Double) (Matrix Double, Vector Double) (Vector Double)
+      pl1 = linearP (3, 2)
+  let res1 = fwd (plens pl1) (m, x) -- [50 122]
+  let res2 = rev (plens pl1) (loss, (m, x)) -- ([[70, 80, 90], [140, 160, 180]], [90, 120, 150])
 
-  let pl :: Para' ModelParam (ModelParam, Input) Result
-      pl = dense (5, 3) identityL
-  -- let res = fwd (plens pl) (((), (b, m)), x) -- [150, 222]
-  let res = rev (plens pl) (loss, ((EmptyParam, (b, m)), x))
+  let pl2 :: Para' ModelParam (ModelParam, Input) Result
+      pl2 = dense (5, 3) identityL
+  let res3 = fwd (plens pl2) ((EmptyParam, (b, m)), x) -- [150, 222]
+  let res4 = rev (plens pl2) (loss, ((EmptyParam, (b, m)), x))
 
-  print res
+  print res1
+  print res2
+  print res3
+  print res4
 
 -- print (params pl)
 
 testCap :: IO ()
 testCap = do
-  let loss :: Matrix Double
-      loss = fromList 2 1 [10, 20]
+  let loss :: Vector Double
+      loss = fromList [10, 20]
 
   let l :: Lens s Double () ()
       l = lr 0.01
   let pc = liftPara l
 
-  -- let res = fwd (plens pc) (params pc, loss) -- ()
-  let res = rev (plens pc) ((), (loss, ()))
+  let res1 = fwd (plens pc) (params pc, loss) -- ()
+  let res2 = rev (plens pc) ((), (loss, ())) -- (loss, 0.01)
 
-  print res
-  print 1
+  print res1
+  print res2
 
 testLoss :: IO ()
 testLoss = do
-  let y :: Matrix Double
-      y = fromList 2 1 [150, 222]
+  let y :: Vector Double
+      y = fromList [150, 222]
 
-  let ey :: Matrix Double
-      ey = fromList 2 1 [140, 202]
+  let ey :: Vector Double
+      ey = fromList [140, 202]
 
-  let l :: Fractional a => Lens' (Matrix a, Matrix a) a
+  let l :: Lens' (Vector Double, Vector Double) Double
       l = mse
 
   let lr :: Double
       lr = -0.01
 
-  let pl :: Fractional a => Para' (Matrix Double) (Matrix a, Matrix a) a
-      pl = Para (fromLists [[]]) l
+  let pl :: Para' (Vector Double) (Vector Double, Vector Double) Double
+      pl = Para (fromList []) l
 
-  -- let res = fwd (plens pl) (y, ey)
-  let res = rev (plens pl) (lr, (y, ey))
+  let res1 = fwd (plens pl) (y, ey)
+  let res2 = rev (plens pl) (lr, (y, ey))
 
-  print res
+  print res1
+  print res2
 
 testActivation :: IO ()
 testActivation = do
   let m :: Matrix Double
       m = fromLists [[0.01, -0.02, 0.03], [0.04, 0.05, -0.06]]
 
-  let x :: Matrix Double
-      x = fromList 3 1 [-0.07, 0.08, 0.09]
+  let x :: Vector Double
+      x = fromList [-0.07, 0.08, 0.09]
 
-  let y :: Matrix Double
-      y = fromList 2 1 [0.0004, -0.0042]
+  let y :: Vector Double
+      y = fromList [0.0004, -0.0042]
 
-  let b :: Matrix Double
-      b = fromList 2 1 [1.0, 1.0]
+  let b :: Vector Double
+      b = fromList [1.0, 1.0]
 
-  let loss :: Matrix Double
-      loss = fromList 2 1 [0.1, 0.2]
+  let loss :: Vector Double
+      loss = fromList [0.1, 0.2]
 
   let pl :: Para' ModelParam (ModelParam, Input) Result
       pl = dense (5, 3) sigmoid
-  -- let res = fwd (plens pl) (((), (b, m)), x)
-  let res = rev (plens pl) (loss, ((EmptyParam, (b, m)), x))
+  let res1 = fwd (plens pl) ((EmptyParam, (b, m)), x)
+  let res2 = rev (plens pl) (loss, ((EmptyParam, (b, m)), x))
 
-  print res
+  print res1
+  print res2
 
 testPipeline :: IO ()
 testPipeline = do
@@ -128,10 +133,10 @@ testPipeline = do
       model = dense (4, 3) sigmoid
 
   let x :: Input
-      x = fromList 4 1 [-0.07, 0.08, 0.09, 0.06]
+      x = fromList [-0.07, 0.08, 0.09, 0.06]
 
-  let ey :: Matrix Double
-      ey = fromList 3 1 [1.0, 0, 0]
+  let ey :: Vector Double
+      ey = fromList [1.0, 0, 0]
 
   let mwu :: Para' ModelParam (ModelParam, Input) Result
       mwu = Para (params model) ((update `alongside` id) . plens model)
@@ -140,7 +145,7 @@ testPipeline = do
       cap = liftPara $ lr 0.01
 
   let loss :: Para LossParam (Result, Expected) (Result, Result) Loss Double
-      loss = Para (fromLists [[]]) mse
+      loss = Para (fromList []) mse
 
   let learner :: Para' LearnerParam (LearnerParam, Input) ()
       learner = mwu |.| (loss |.| cap)

--- a/OpticML/src/OpticML/Components.hs
+++ b/OpticML/src/OpticML/Components.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module OpticML.Components
   ( dense,
@@ -10,18 +11,18 @@ where
 import OpticML.Parametric (Para(..), Para', (|.|), liftPara, EmptyParam(..))
 import System.Random (Random)
 import Data.Random.Normal ( mkNormals )
-import Data.Matrix (Matrix, zero, fromList)
+import Numeric.LinearAlgebra (Matrix, Vector, (><), Konst (konst), Numeric)
 import OpticML.LensImpl (linear, add)
 import OpticML.Lenses (Lens')
 
 seed :: Int
 seed = 384723978470123987
 
-dense :: (Floating a, Random a) => (Int, Int) -> Lens' (Matrix a) (Matrix a) -> Para' (EmptyParam, (Matrix a, Matrix a)) ((EmptyParam, (Matrix a, Matrix a)), Matrix a) (Matrix a)
+dense :: (Numeric a, Floating a, Random a, Num (Vector a)) => (Int, Int) -> Lens' (Vector a) (Vector a) -> Para' (EmptyParam, (Vector a, Matrix a)) ((EmptyParam, (Vector a, Matrix a)), Vector a) (Vector a)
 dense (a, b) act = linearP (a, b) |.| biasP b |.| liftPara act
 
-linearP :: (Floating a, Random a) => (Int, Int) -> Para' (Matrix a) (Matrix a, Matrix a) (Matrix a)
-linearP (a, b) = Para (fromList b a $ take (a * b) (mkNormals seed)) linear
+linearP :: (Numeric a, Floating a, Random a) => (Int, Int) -> Para' (Matrix a) (Matrix a, Vector a) (Vector a)
+linearP (a, b) = Para (b >< a $ take (a * b) (mkNormals seed)) linear
 
-biasP :: Num a => Int -> Para' (Matrix a) (Matrix a, Matrix a) (Matrix a)
-biasP b = Para (zero b 1) add
+biasP :: (Numeric a, Num (Vector a)) => Int -> Para' (Vector a) (Vector a, Vector a) (Vector a)
+biasP b = Para (konst 0 b) add

--- a/OpticML/src/OpticML/Parametric.hs
+++ b/OpticML/src/OpticML/Parametric.hs
@@ -22,7 +22,7 @@ data Para p s t a b = Para
 
 type Para' p s a = Para p s s a a
 
-data EmptyParam = EmptyParam deriving stock Show
+data EmptyParam = EmptyParam deriving stock (Show, Eq)
 
 instance (Num a, Num b) => Num (a,b) where
   fromInteger n   = (fromInteger n, fromInteger n)

--- a/OpticML/test/Tests.hs
+++ b/OpticML/test/Tests.hs
@@ -1,13 +1,15 @@
+{-# LANGUAGE RankNTypes #-}
 module Main (main) where
 
 import Test.Tasty
 import Test.Tasty.HUnit
 import OpticML
+import Data.Matrix (Matrix, fromList, fromLists)
 
 main = defaultMain tests
 
 tests :: TestTree
-tests = testGroup "Testing OpticML" [lensUnitTests]
+tests = testGroup "Testing OpticML" [lensUnitTests, capUnitTests, modelUnitTests, lossUnitTests, activationUnitTests, pipelineUnitTests]
 
 lensUnitTests = testGroup "Lens Unit Tets (run via HUnit)"
     [ testCase "view p1" $
@@ -17,3 +19,163 @@ lensUnitTests = testGroup "Lens Unit Tets (run via HUnit)"
     , testCase "over p1" $
         over p1 (+1) (1, 2) @?= (2, 2)
     ]
+
+type ModelParam = (EmptyParam, (Matrix Double, Matrix Double))
+type Result = Matrix Double
+type Input = Matrix Double
+type Expected = Matrix Double
+type Loss = Double
+
+type LRParam = EmptyParam
+type LossParam = Matrix Double
+type LearnerParam = ((LRParam, LossParam), ModelParam)
+
+modelUnitTests = testGroup "Model Unit Tets (run via HUnit)"
+    [ testCase "testLinearFwd" $ 
+        fwd (plens pl1) (m, x) @?= fromList 2 1 [50, 122]
+    , testCase "testLinearRev" $ 
+        rev (plens pl1) (loss, (m, x)) @?= (m', x')
+    , testCase "testDenseFwd" $ 
+        fwd (plens pl2) ((EmptyParam, (b, m)), x) @?= fromList 2 1 [150, 222]
+    , testCase "testDenseRev" $ 
+        rev (plens pl2) (loss, ((EmptyParam, (b, m)), x)) @?= ((EmptyParam, (loss, m')), x')
+    ]
+    where
+        m :: Matrix Double
+        m = fromLists [[1, 2, 3], [4, 5, 6]]
+
+        x :: Matrix Double
+        x = fromList 3 1 [7, 8, 9]
+
+        y :: Matrix Double
+        y = fromList 2 1 [150, 222]
+
+        b :: Matrix Double
+        b = fromList 2 1 [100, 100]
+
+        loss :: Matrix Double
+        loss = fromList 2 1 [10, 20]
+
+        m' :: Matrix Double
+        m' =
+                fromLists
+                [ [70, 80, 90],
+                    [140, 160, 180]
+                ]
+
+        x' :: Matrix Double
+        x' = fromList 3 1 [90, 120, 150]
+
+        pl1 :: Para' (Matrix Double) (Matrix Double, Matrix Double) (Matrix Double)
+        pl1 = linearP (3, 2)
+
+        pl2 :: Para' ModelParam (ModelParam, Input) Result
+        pl2 = dense (5, 3) identityL
+
+capUnitTests = testGroup "Cap Unit Tets (run via HUnit)"
+    [ testCase "testCapFwd" $ 
+        fwd (plens pc) (params pc, loss) @?= ()
+    , testCase "testCapRev" $ 
+        rev (plens pc) ((), (loss, ())) @?= (loss, -0.01)
+    ]
+    where
+        loss :: Matrix Double
+        loss = fromList 2 1 [10, 20]
+
+        l :: Lens s Double () ()
+        l = lr (-0.01)
+        pc = liftPara l
+
+lossUnitTests = testGroup "Loss Unit Tets (run via HUnit)"
+    [ testCase "testLossFwd" $ 
+        fwd (plens pl) (y, ey) @?= 250
+    , testCase "testLossRev" $ 
+        rev (plens pl) (lr, (y, ey)) @?= (fromLists [[]], fromList 2 1 [-0.1, -0.2])
+    ]
+    where
+        y :: Matrix Double
+        y = fromList 2 1 [150, 222]
+
+        ey :: Matrix Double
+        ey = fromList 2 1 [140, 202]
+
+        l :: Fractional a => Lens' (Matrix a, Matrix a) a
+        l = mse
+
+        lr :: Double
+        lr = -0.01
+
+        pl :: Fractional a => Para' (Matrix Double) (Matrix a, Matrix a) a
+        pl = Para (fromLists [[]]) l
+
+activationUnitTests = testGroup "Activation Unit Tets (run via HUnit)"
+    [ testCase "testActivationFwd" $ 
+        fwd (plens pl) ((EmptyParam, (b, m)), x) @?= fromList 2 1 [0.7311372161343049, 0.7302320075828583]
+    , testCase "testActivationRev" $ 
+        rev (plens pl) (loss, ((EmptyParam, (b, m)), x)) @?= 
+            ((EmptyParam, (fromList 2 1 [1.965755873176836e-2, 3.9398644536873334e-2], 
+                           fromLists [[-1.3760291112237854e-3, 1.5726046985414688e-3, 1.7691802858591523e-3], 
+                                      [-2.757905117581134e-3, 3.151891562949867e-3, 3.5458780083186e-3]])
+             ), fromList 3 1 [1.772521368792617e-3, 1.5767810522082997e-3,-1.7741919102593493e-3])
+    ]
+    where
+        m :: Matrix Double
+        m = fromLists [[0.01, -0.02, 0.03], [0.04, 0.05, -0.06]]
+
+        x :: Matrix Double
+        x = fromList 3 1 [-0.07, 0.08, 0.09]
+
+        y :: Matrix Double
+        y = fromList 2 1 [0.0004, -0.0042]
+
+        b :: Matrix Double
+        b = fromList 2 1 [1.0, 1.0]
+
+        loss :: Matrix Double
+        loss = fromList 2 1 [0.1, 0.2]
+
+        pl :: Para' ModelParam (ModelParam, Input) Result
+        pl = dense (5, 3) sigmoid
+
+pipelineUnitTests = testGroup "Pipeline Unit Tets (run via HUnit)"
+    [ testCase "testPipelineRev" $ 
+        rev (plens learner) ((), input) @?= ((  (EmptyParam, fromLists [[]]), 
+                                                (EmptyParam, (nb, nm))), x')
+    ]
+    where
+        model :: Para' ModelParam (ModelParam, Input) Result
+        model = dense (4, 3) sigmoid
+
+        x :: Input
+        x = fromList 4 1 [-0.07, 0.08, 0.09, 0.06]
+
+        ey :: Matrix Double
+        ey = fromList 3 1 [1.0, 0, 0]
+
+        mwu :: Para' ModelParam (ModelParam, Input) Result
+        mwu = Para (params model) ((update `alongside` id) . plens model)
+
+        cap :: Para LRParam (LRParam, Loss) (LRParam, Loss) () ()
+        cap = liftPara $ lr 0.01
+
+        loss :: Para LossParam (Result, Expected) (Result, Result) Loss Double
+        loss = Para (fromLists [[]]) mse
+
+        learner :: Para' LearnerParam (LearnerParam, Input) ()
+        learner = mwu |.| (loss |.| cap)
+
+        input :: (((LRParam, Expected), ModelParam), Input)
+        input = (((lrp, ey), mp), x)
+                where
+                ((lrp, _), mp) = params learner
+
+        x' :: Matrix Double
+        x' = fromList 4 1 [-6.776498013458829e-5, -2.176261941939712e-3, -1.1495594636975863e-3,  6.528513067859352e-4]
+
+        nb :: Matrix Double
+        nb = fromList 3 1 [1.3217990661356168e-3, -1.321785313330119e-3, -1.2005843745919909e-3]
+
+        nm :: Matrix Double
+        nm = fromLists [[-0.19262571524635072, -0.9583693677191268, -1.2018934446323384, 0.805625851575068],
+                        [-0.13910418485692538, 1.3458636581796626, -0.3937374245822127, 0.6837179918588936],
+                        [-2.195718051184199e-3, -0.7245200609151277, 6.737549424992297e-2, -0.4098007265059785]]

--- a/OpticML/test/Tests.hs
+++ b/OpticML/test/Tests.hs
@@ -4,7 +4,7 @@ module Main (main) where
 import Test.Tasty
 import Test.Tasty.HUnit
 import OpticML
-import Data.Matrix (Matrix, fromList, fromLists)
+import Numeric.LinearAlgebra (Matrix, Vector, fromLists, fromList)
 
 main = defaultMain tests
 
@@ -20,23 +20,23 @@ lensUnitTests = testGroup "Lens Unit Tets (run via HUnit)"
         over p1 (+1) (1, 2) @?= (2, 2)
     ]
 
-type ModelParam = (EmptyParam, (Matrix Double, Matrix Double))
-type Result = Matrix Double
-type Input = Matrix Double
-type Expected = Matrix Double
+type ModelParam = (EmptyParam, (Vector Double, Matrix Double))
+type Result = Vector Double
+type Input = Vector Double
+type Expected = Vector Double
 type Loss = Double
 
 type LRParam = EmptyParam
-type LossParam = Matrix Double
+type LossParam = Vector Double
 type LearnerParam = ((LRParam, LossParam), ModelParam)
 
 modelUnitTests = testGroup "Model Unit Tets (run via HUnit)"
     [ testCase "testLinearFwd" $ 
-        fwd (plens pl1) (m, x) @?= fromList 2 1 [50, 122]
+        fwd (plens pl1) (m, x) @?= fromList [50, 122]
     , testCase "testLinearRev" $ 
         rev (plens pl1) (loss, (m, x)) @?= (m', x')
     , testCase "testDenseFwd" $ 
-        fwd (plens pl2) ((EmptyParam, (b, m)), x) @?= fromList 2 1 [150, 222]
+        fwd (plens pl2) ((EmptyParam, (b, m)), x) @?= fromList [150, 222]
     , testCase "testDenseRev" $ 
         rev (plens pl2) (loss, ((EmptyParam, (b, m)), x)) @?= ((EmptyParam, (loss, m')), x')
     ]
@@ -44,17 +44,17 @@ modelUnitTests = testGroup "Model Unit Tets (run via HUnit)"
         m :: Matrix Double
         m = fromLists [[1, 2, 3], [4, 5, 6]]
 
-        x :: Matrix Double
-        x = fromList 3 1 [7, 8, 9]
+        x :: Vector Double
+        x = fromList [7, 8, 9]
 
-        y :: Matrix Double
-        y = fromList 2 1 [150, 222]
+        y :: Vector Double
+        y = fromList [150, 222]
 
-        b :: Matrix Double
-        b = fromList 2 1 [100, 100]
+        b :: Vector Double
+        b = fromList [100, 100]
 
-        loss :: Matrix Double
-        loss = fromList 2 1 [10, 20]
+        loss :: Vector Double
+        loss = fromList [10, 20]
 
         m' :: Matrix Double
         m' =
@@ -63,10 +63,10 @@ modelUnitTests = testGroup "Model Unit Tets (run via HUnit)"
                     [140, 160, 180]
                 ]
 
-        x' :: Matrix Double
-        x' = fromList 3 1 [90, 120, 150]
+        x' :: Vector Double
+        x' = fromList [90, 120, 150]
 
-        pl1 :: Para' (Matrix Double) (Matrix Double, Matrix Double) (Matrix Double)
+        pl1 :: Para' (Matrix Double) (Matrix Double, Vector Double) (Vector Double)
         pl1 = linearP (3, 2)
 
         pl2 :: Para' ModelParam (ModelParam, Input) Result
@@ -79,8 +79,8 @@ capUnitTests = testGroup "Cap Unit Tets (run via HUnit)"
         rev (plens pc) ((), (loss, ())) @?= (loss, -0.01)
     ]
     where
-        loss :: Matrix Double
-        loss = fromList 2 1 [10, 20]
+        loss :: Vector Double
+        loss = fromList [10, 20]
 
         l :: Lens s Double () ()
         l = lr (-0.01)
@@ -90,56 +90,56 @@ lossUnitTests = testGroup "Loss Unit Tets (run via HUnit)"
     [ testCase "testLossFwd" $ 
         fwd (plens pl) (y, ey) @?= 250
     , testCase "testLossRev" $ 
-        rev (plens pl) (lr, (y, ey)) @?= (fromLists [[]], fromList 2 1 [-0.1, -0.2])
+        rev (plens pl) (lr, (y, ey)) @?= (fromList [], fromList [-0.1, -0.2])
     ]
     where
-        y :: Matrix Double
-        y = fromList 2 1 [150, 222]
+        y :: Vector Double
+        y = fromList [150, 222]
 
-        ey :: Matrix Double
-        ey = fromList 2 1 [140, 202]
+        ey :: Vector Double
+        ey = fromList [140, 202]
 
-        l :: Fractional a => Lens' (Matrix a, Matrix a) a
+        l :: Lens' (Vector Double, Vector Double) Double
         l = mse
 
         lr :: Double
         lr = -0.01
 
-        pl :: Fractional a => Para' (Matrix Double) (Matrix a, Matrix a) a
-        pl = Para (fromLists [[]]) l
+        pl :: Para' (Vector Double) (Vector Double, Vector Double) Double
+        pl = Para (fromList []) l
 
 activationUnitTests = testGroup "Activation Unit Tets (run via HUnit)"
     [ testCase "testActivationFwd" $ 
-        fwd (plens pl) ((EmptyParam, (b, m)), x) @?= fromList 2 1 [0.7311372161343049, 0.7302320075828583]
+        fwd (plens pl) ((EmptyParam, (b, m)), x) @?= fromList [0.7311372161343049, 0.7302320075828583]
     , testCase "testActivationRev" $ 
         rev (plens pl) (loss, ((EmptyParam, (b, m)), x)) @?= 
-            ((EmptyParam, (fromList 2 1 [1.965755873176836e-2, 3.9398644536873334e-2], 
+            ((EmptyParam, (fromList [1.965755873176836e-2, 3.9398644536873334e-2], 
                            fromLists [[-1.3760291112237854e-3, 1.5726046985414688e-3, 1.7691802858591523e-3], 
                                       [-2.757905117581134e-3, 3.151891562949867e-3, 3.5458780083186e-3]])
-             ), fromList 3 1 [1.772521368792617e-3, 1.5767810522082997e-3,-1.7741919102593493e-3])
+             ), fromList [1.772521368792617e-3, 1.5767810522082997e-3,-1.7741919102593493e-3])
     ]
     where
         m :: Matrix Double
         m = fromLists [[0.01, -0.02, 0.03], [0.04, 0.05, -0.06]]
 
-        x :: Matrix Double
-        x = fromList 3 1 [-0.07, 0.08, 0.09]
+        x :: Vector Double
+        x = fromList [-0.07, 0.08, 0.09]
 
-        y :: Matrix Double
-        y = fromList 2 1 [0.0004, -0.0042]
+        y :: Vector Double
+        y = fromList [0.0004, -0.0042]
 
-        b :: Matrix Double
-        b = fromList 2 1 [1.0, 1.0]
+        b :: Vector Double
+        b = fromList [1.0, 1.0]
 
-        loss :: Matrix Double
-        loss = fromList 2 1 [0.1, 0.2]
+        loss :: Vector Double
+        loss = fromList [0.1, 0.2]
 
         pl :: Para' ModelParam (ModelParam, Input) Result
         pl = dense (5, 3) sigmoid
 
 pipelineUnitTests = testGroup "Pipeline Unit Tets (run via HUnit)"
     [ testCase "testPipelineRev" $ 
-        rev (plens learner) ((), input) @?= ((  (EmptyParam, fromLists [[]]), 
+        rev (plens learner) ((), input) @?= ((  (EmptyParam, fromList []), 
                                                 (EmptyParam, (nb, nm))), x')
     ]
     where
@@ -147,10 +147,10 @@ pipelineUnitTests = testGroup "Pipeline Unit Tets (run via HUnit)"
         model = dense (4, 3) sigmoid
 
         x :: Input
-        x = fromList 4 1 [-0.07, 0.08, 0.09, 0.06]
+        x = fromList [-0.07, 0.08, 0.09, 0.06]
 
-        ey :: Matrix Double
-        ey = fromList 3 1 [1.0, 0, 0]
+        ey :: Vector Double
+        ey = fromList [1.0, 0, 0]
 
         mwu :: Para' ModelParam (ModelParam, Input) Result
         mwu = Para (params model) ((update `alongside` id) . plens model)
@@ -159,7 +159,7 @@ pipelineUnitTests = testGroup "Pipeline Unit Tets (run via HUnit)"
         cap = liftPara $ lr 0.01
 
         loss :: Para LossParam (Result, Expected) (Result, Result) Loss Double
-        loss = Para (fromLists [[]]) mse
+        loss = Para (fromList []) mse
 
         learner :: Para' LearnerParam (LearnerParam, Input) ()
         learner = mwu |.| (loss |.| cap)
@@ -169,11 +169,11 @@ pipelineUnitTests = testGroup "Pipeline Unit Tets (run via HUnit)"
                 where
                 ((lrp, _), mp) = params learner
 
-        x' :: Matrix Double
-        x' = fromList 4 1 [-6.776498013458829e-5, -2.176261941939712e-3, -1.1495594636975863e-3,  6.528513067859352e-4]
+        x' :: Vector Double
+        x' = fromList [-6.776498013458829e-5, -2.176261941939712e-3, -1.1495594636975863e-3,  6.528513067859352e-4]
 
-        nb :: Matrix Double
-        nb = fromList 3 1 [1.3217990661356168e-3, -1.321785313330119e-3, -1.2005843745919909e-3]
+        nb :: Vector Double
+        nb = fromList [1.3217990661356168e-3, -1.321785313330119e-3, -1.2005843745919909e-3]
 
         nm :: Matrix Double
         nm = fromLists [[-0.19262571524635072, -0.9583693677191268, -1.2018934446323384, 0.805625851575068],


### PR DESCRIPTION
Replace the native Haskell `Data.Matrix` library with BLAS Interface library `hmatrix` for improved performance and additional features.